### PR TITLE
Adding steps to create SSL certificate for GSA domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ usage: installvm.py [-h] --host-ip HOST_IP --host-name HOST_NAME --host-gw
                     [--hmc-userid HMC_USERID] [--hmc-password HMC_PASSWORD]
                     [--hmc-profile HMC_PROFILE] [--ksargs KSARGS]
                     [--showcleanup SHOWCLEANUP] --distro DISTRO
-                    [--set-boot-order SET_BOOT_ORDER]
+                    [--set-boot-order SET_BOOT_ORDER] --ssl-server SSL_SERVER
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -21,6 +21,7 @@ optional arguments:
                         sles_11sp3_beta
   --set-boot-order SET_BOOT_ORDER
                         yes/True to set the boot disk order
+  --ssl-server SSL_SERVER  SSL certificate for the server domain to be created in LPAR
 
 Host Specific Information for Installation:
 

--- a/installvm.py
+++ b/installvm.py
@@ -275,6 +275,16 @@ class Distro():
         cmd = 'touch /etc/%s' % vmParser.args.distro
         self.runCommandcleanup(self.system, cmd)
 
+    def cacert_addinsystem(self):
+        self.system = paramiko.SSHClient()
+        self.system.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.system.connect(vmParser.args.host_ip, username='root',
+                            password=vmParser.args.host_password)
+        cmd = 'openssl s_client -showcerts -servername %s -connect %s:443 > /etc/pki/trust/anchors/cacert.pem' % (vmParser.args.ssl_server, vmParser.args.ssl_server)
+        self.runCommand(self.system, cmd)
+        cmd = 'update-ca-certificates'
+        self.runCommand(self.system, cmd)
+
 
 class Rhel(Distro):
 
@@ -659,4 +669,6 @@ if __name__ == "__main__":
     vmInst.monitorInstallation()
     vmInst.cleanup()
     vmInst.file_addinsystem()
+    if vmParser.args.ssl_server and distro.upper() == 'SLES':
+        vmInst.cacert_addinsystem()
     copylog()

--- a/lib/configparser.py
+++ b/lib/configparser.py
@@ -75,6 +75,8 @@ class CmdLineArgParser():
             '--distro', help='distro to be installed ex: rhel_7.4le_alpa, sles_11sp3_beta', required=True)
         parser.add_argument(
             '--set-boot-order', help='yes/True to set the boot disk order', required=False)
+        parser.add_argument(
+            '--ssl-server', help='SSL certificate for the server domain to be created in LPAR', required=False)
 
         self.args = parser.parse_args()
         self.domain = (self.args.host_name).split('.', 1)[1]


### PR DESCRIPTION
To get a client certificate for GSA communication adding a step to create the certificate inside the lpar after the installation
A input variable gsa-server is required to get the gsa server doamin name