### PR TITLE
NFS mode of installation

### DIFF
--- a/installvm.py
+++ b/installvm.py
@@ -330,15 +330,23 @@ class Rhel(Distro):
             for disk in disks:
                 host_disk += '/dev/disk/by-id/' + disk+','
             vmParser.args.host_disk = host_disk.rstrip(',')
+        if vmParser.args.install_protocol == 'http':
+            if version.startswith('8') or  version.startswith('9') or version.startswith('10'):
+                lstr = "%end"
+                urlstring = "--url=http://"+vmParser.confparser('repo', 'RepoIP') + ':' + vmParser.confparser('repo', 'RepoPort') + \
+                    self.repoDir + "/BaseOS"
+            else:
+                lstr = "telnet\njava\n%end"
+                urlstring = "--url=http://"+vmParser.confparser('repo', 'RepoIP') + ':' + vmParser.confparser('repo', 'RepoPort') + \
+                    self.repoDir 
 
-        if version.startswith('8') or  version.startswith('9') or version.startswith('10'):
-            lstr = "%end"
-            urlstring = "--url=http://"+vmParser.confparser('repo', 'RepoIP') + ':' + vmParser.confparser('repo', 'RepoPort') + \
-                self.repoDir + "/BaseOS"
-        else:
-            lstr = "telnet\njava\n%end"
-            urlstring = "--url=http://"+vmParser.confparser('repo', 'RepoIP') + ':' + vmParser.confparser('repo', 'RepoPort') + \
-                self.repoDir 
+        if vmParser.args.install_protocol == 'nfs':
+            if version.startswith('8') or  version.startswith('9') or version.startswith('10'):
+                lstr = "%end"
+                urlstring = "--url=nfs://"+vmParser.confparser('repo', 'RepoIP') + ':/var/www/html' + self.repoDir +  "/BaseOS"
+            else:
+                lstr = "telnet\njava\n%end"
+                urlstring = "--url=nfs://"+vmParser.confparser('repo', 'RepoIP') + ':/var/www/html' + self.repoDir  
 
         if vmParser.args.ksargs == '':
             addksstring = "autopart --type=lvm --fstype=ext4"

--- a/lib/configparser.py
+++ b/lib/configparser.py
@@ -74,6 +74,9 @@ class CmdLineArgParser():
         parser.add_argument(
             '--distro', help='distro to be installed ex: rhel_7.4le_alpa, sles_11sp3_beta', required=True)
         parser.add_argument(
+            '--install-protocol' , help='Mode of Install Protocol ex: http, ftp, nfs',required=True)
+        parser.add_argument('--fs-type' ,help='RootFS type ex: xfs, ext4, btrfs', default='xfs')
+        parser.add_argument(
             '--set-boot-order', help='yes/True to set the boot disk order', required=False)
         parser.add_argument(
             '--ssl-server', help='SSL certificate for the server domain to be created in LPAR', required=False)


### PR DESCRIPTION
* This code is enhanced to support nfs installation.
* A new parameter is added --install-protocol to ensure which protocol(http,nfs) needs to be used for installation
* Eg., --install-protocol nfs , this will switch to nfs:// path at the server which will serve as the install medium